### PR TITLE
Support PWA feature

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+sotapwiki.jimmy0w0.me

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-sotapwiki.jimmy0w0.me

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 	<link href="https://fonts.loli.net/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 	<link rel="icon" href="https://sotap.oss-cn-qingdao.aliyuncs.com/favicon.ico">
 	<link rel="stylesheet" href="//unpkg.com/gitalk/dist/gitalk.css">
+	<link rel="manifest" href="/manifest.json">
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 	<link href="https://fonts.loli.net/css?family=Poppins:700|Source+Sans+Pro&display=swap" rel="stylesheet">
 	<link href="https://fonts.loli.net/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
 	<link rel="icon" href="https://sotap.oss-cn-qingdao.aliyuncs.com/favicon.ico">
+	<link rel="apple-touch-icon" href="https://sotap.oss-cn-qingdao.aliyuncs.com/favicon.ico">
 	<link rel="stylesheet" href="//unpkg.com/gitalk/dist/gitalk.css">
 	<link rel="manifest" href="/manifest.json">
 </head>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,39 @@
+{
+    "name": "SotapWiki",
+    "short_name": "SotapWiki",
+    "start_url": "/",
+    "display": "standalone",
+    "background_color": "#fff",
+    "theme_color": "#fff",
+    "manifest_version": 2,
+    "version": "1.0",
+    "icons": [
+        {
+            "src": "https://somethings-1252552907.cos.ap-guangzhou.myqcloud.com/sotap_120x120.png",
+            "sizes": "120x120",
+            "type": "image/png"
+        },
+
+        {
+            "src": "https://somethings-1252552907.cos.ap-guangzhou.myqcloud.com/sotap_144x144.png",
+            "sizes": "144x144",
+            "type": "image/png"
+        },
+
+        {
+            "src": "https://somethings-1252552907.cos.ap-guangzhou.myqcloud.com/sotap_192x192.png",
+            "sizes": "192x192",
+            "type": "image/png"
+        },
+
+        {
+            "src": "https://somethings-1252552907.cos.ap-guangzhou.myqcloud.com/sotap_512x512.png",
+            "sizes": "512x512",
+            "type": "image/png"
+        }
+    ],
+    "browser_action":{
+        "default_title": "SotapWiki",
+        "default_popup": "index.html"
+    }
+}


### PR DESCRIPTION
## 更新
- 新增 `manifest.json`

- 修改 `index.html`

## 期望
使Sotap Wiki的网站支持PWA (渐进式Web应用) 特性

让iOS设备在将Sotap Wiki添加到主页的时候可以显示正常的图标 - (未测试，实现为`<link rel="apple-touch-icon" href="https://sotap.oss-cn-qingdao.aliyuncs.com/favicon.ico">`)

## 结果
经过了Chrome (Windows 10) 和 Safari (iOS 13.4, iPhone SE) 测试，PWA特性正常运行

## 截图 (图片加载稍慢)
- Chrome安装PWA

![](https://s1.ax1x.com/2020/04/05/GBn0Qx.png)

- Chrome的PWA独立窗口

![](https://s1.ax1x.com/2020/04/05/GBnBy6.png)

- Safari的PWA独立窗口 (多任务切换)

![](https://s1.ax1x.com/2020/04/05/GBnDOK.png)

- Safari的PWA独立窗口

![](https://s1.ax1x.com/2020/04/05/GBnaWR.png)

## 其他 (留言)
因为Sotap Wiki的icon不符合PWA的图标要求，所以只能抓了一个官网上的图标改了下尺寸，效果并不理想，请谅解😉

如果有适合的图标资源可以发给我 (Telegram, QQ, Email)，或者可以自行修改`manifest.json`

关于第二次commit的Unverified是因为Windows配置的是其他邮箱没注意，第三次commit改回来了，是我本人XD